### PR TITLE
Fix token handling and streamline UI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ This project was fork from https://github.com/DarkModde/WPlace-AutoBOT
 ### 🎯┃Auto-Farm
 #### AUTOFARM USES CHARGES TO GET LEVELS, IT DOES NOT DRAW AN IMAGE FOR YOU. PLEASE USE AUTO-IMAGE FOR THAT
 ```js
-javascript:fetch("https://raw.githubusercontent.com/Wplace-AutoBot/WPlace-AutoBOT/refs/heads/main/Auto-Farm.js").then(t=>t.text()).then(eval);
+javascript:fetch("https://raw.githubusercontent.com/Tenosiey/WPlace-AutoBOT/refs/heads/main/Auto-Farm.js").then(t=>t.text()).then(eval);
 ```
 
 ### 🖼️┃Auto-Image
 
 ```js
-javascript:fetch("https://raw.githubusercontent.com/Wplace-AutoBot/WPlace-AutoBOT/refs/heads/main/Auto-Image.js").then(t=>t.text()).then(eval);
+javascript:fetch("https://raw.githubusercontent.com/Tenosiey/WPlace-AutoBOT/refs/heads/main/Auto-Image.js").then(t=>t.text()).then(eval);
 ```
 
 <details>


### PR DESCRIPTION
## Summary
- cache UI elements to reduce DOM queries
- handle expired CAPTCHA token without undefined variable
- point README bookmarklets to Tenosiey fork

## Testing
- `node --check Auto-Farm.js`
- `node --check Auto-Image.js`


------
https://chatgpt.com/codex/tasks/task_e_68a856add5d083279d2dddec9e81df54